### PR TITLE
Enable restart behavior on start API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This plugin targets Android devices running Marshmellow (API 23), or higher. Thi
 `start(socksServerAddress:string) : Promise<string>;`
 
 Starts the VPN service, and tunnels all the traffic to the SOCKS5 server at `socksServerAddress`.
+Restarts tunneling while preserving the VPN connection if called when the plugin is already running.
 
 `stop(): Promise<string>;`
 

--- a/src/android/org/uproxy/tun2socks/DnsResolverService.java
+++ b/src/android/org/uproxy/tun2socks/DnsResolverService.java
@@ -56,6 +56,10 @@ public class DnsResolverService extends Service {
       Log.e(LOG_TAG, "Failed to receive socks server address.");
       return START_NOT_STICKY;
     }
+
+    if (m_dnsResolver != null) {
+      m_dnsResolver.interrupt();  // Stop resolver to handle reconnect.
+    }
     m_dnsResolver = new DnsUdpToSocksResolver(DnsResolverService.this);
     m_dnsResolver.start();
 
@@ -169,6 +173,7 @@ public class DnsResolverService extends Service {
             e.printStackTrace();
             continue;
           }
+
           if (!writeUdpPacketToStream(dnsOutputStream, udpPacket)) {
             continue;
           }

--- a/src/android/org/uproxy/tun2socks/Tun2Socks.java
+++ b/src/android/org/uproxy/tun2socks/Tun2Socks.java
@@ -140,6 +140,10 @@ public class Tun2Socks extends CordovaPlugin {
     Log.i(LOG_TAG, "starting tunnel service");
     if (isServiceRunning()) {
       Log.w(LOG_TAG, "already running service");
+      TunnelManager tunnelManager = TunnelState.getTunnelState().getTunnelManager();
+      if (tunnelManager != null) {
+        tunnelManager.restartTunnel(m_socksServerAddress);
+      }
       return;
     }
     Intent startTunnelVpn = new Intent(context, TunnelVpnService.class);

--- a/src/android/org/uproxy/tun2socks/Tun2SocksJni.java
+++ b/src/android/org/uproxy/tun2socks/Tun2SocksJni.java
@@ -15,8 +15,8 @@ public class Tun2SocksJni {
   // udpgw server.
   //
   // The tun device file descriptor should be set to non-blocking mode.
-  // tun2Socks takes ownership of the tun device file descriptor and will close
-  // it when tun2socks is stopped.
+  // tun2Socks does *not* take ownership of the tun device file descriptor; the
+  // caller is responsible for closing it after tun2socks terminates.
   //
   // runTun2Socks blocks until tun2socks is stopped by calling terminateTun2Socks.
   // It's safe to call terminateTun2Socks from a different thread.

--- a/src/android/org/uproxy/tun2socks/Tunnel.java
+++ b/src/android/org/uproxy/tun2socks/Tunnel.java
@@ -204,7 +204,6 @@ public class Tunnel {
 
   private void stopRoutingThroughTunnel() {
     stopTun2Socks();
-    mRoutingThroughTunnel.set(false);
   }
 
   @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)

--- a/src/android/org/uproxy/tun2socks/TunnelVpnService.java
+++ b/src/android/org/uproxy/tun2socks/TunnelVpnService.java
@@ -68,6 +68,7 @@ public class TunnelVpnService extends VpnService {
 
   @Override
   public void onDestroy() {
+    Log.d(LOG_TAG, "on destroy");
     TunnelState.getTunnelState().setTunnelManager(null);
     m_tunnelManager.onDestroy();
   }

--- a/src/badvpn/tun2socks/tun2socks.c
+++ b/src/badvpn/tun2socks/tun2socks.c
@@ -298,7 +298,7 @@ static void udp_fd_handler(UdpPcb* udp_pcb, int event) {
     dns_get_header_id_str(dns_id_str, udp_pcb->udp_recv_buffer);
     const char* local_addr_str = BStringMap_Get(&udp_pcb->map, dns_id_str);
     if (!local_addr_str) {
-        BLog(BLOG_ERROR, "udp_fd_handler: no address for dns reqeust id %s",
+        BLog(BLOG_ERROR, "udp_fd_handler: no address for DNS request id %s",
              dns_id_str);
         return;
     }

--- a/src/badvpn/tuntap/BTap.c
+++ b/src/badvpn/tuntap/BTap.c
@@ -488,7 +488,10 @@ int BTap_InitWithFD (BTap *o, BReactor *reactor, int fd, int mtu, BTap_handler_e
     o->handler_error_user = handler_error_user;
     o->frame_mtu = mtu;
     o->fd = fd;
-    o->close_fd = 1;
+    // ===== UPROXY =====
+    // Do not take ownership or close the TUN file descriptor
+    o->close_fd = 0;
+    // ===== /UPROXY =====
 
     // TODO: use BTap_Init2? Still some different behavior (we don't want the fcntl block; we do want close to be called)
 


### PR DESCRIPTION
- Allows plugin users to restart tunneling (tun2socks) with a new SOCKS server address, without stopping the VPN.
- The DNS resolver also restarts.
- As a side effect, tun2socks does not take ownership of the VPN (TUN) interface anymore - the caller is now responsible for closing it after stopping tun2socks.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/cordova-plugin-tun2socks/8)

<!-- Reviewable:end -->
