### PR TITLE
Invoke start callback accurately

### DIFF
--- a/src/android/org/uproxy/tun2socks/TunnelVpnService.java
+++ b/src/android/org/uproxy/tun2socks/TunnelVpnService.java
@@ -34,6 +34,10 @@ public class TunnelVpnService extends VpnService {
   private static final String LOG_TAG = "TunnelVpnService";
   public static final String TUNNEL_VPN_DISCONNECT_BROADCAST =
       "tunnelVpnDisconnectBroadcast";
+  public static final String TUNNEL_VPN_START_BROADCAST =
+      "tunnelVpnStartBroadcast";
+  public static final String TUNNEL_VPN_START_SUCCESS_EXTRA =
+      "tunnelVpnStartSuccessExtra";
 
   private TunnelManager m_tunnelManager = new TunnelManager(this);
 
@@ -85,9 +89,21 @@ public class TunnelVpnService extends VpnService {
     return new VpnService.Builder();
   }
 
-  private void broadcastVpnDisconnect() {
-    Intent disconnectBroadcast = new Intent(TUNNEL_VPN_DISCONNECT_BROADCAST);
+  // Broadcast non-user-initiated VPN disconnect.
+  public void broadcastVpnDisconnect() {
+    dispatchBroadcast(new Intent(TUNNEL_VPN_DISCONNECT_BROADCAST));
+  }
+
+  // Broadcast VPN start. |success| is true if the VPN and tunnel were started
+  // successfully, and false otherwise.
+  public void broadcastVpnStart(boolean success) {
+    Intent vpnStart = new Intent(TUNNEL_VPN_START_BROADCAST);
+    vpnStart.putExtra(TUNNEL_VPN_START_SUCCESS_EXTRA, success);
+    dispatchBroadcast(vpnStart);
+  }
+
+  private void dispatchBroadcast(final Intent broadcast) {
     LocalBroadcastManager.getInstance(TunnelVpnService.this)
-        .sendBroadcast(disconnectBroadcast);
+        .sendBroadcast(broadcast);
   }
 }


### PR DESCRIPTION
- Calls with success status only after the VPN is established and the tunnel is routing.
- Calls with error status on failure conditions (including denied VPN permissions by the user).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/cordova-plugin-tun2socks/10)

<!-- Reviewable:end -->
